### PR TITLE
simplified conditions in WineList

### DIFF
--- a/src/components/WineList.jsx
+++ b/src/components/WineList.jsx
@@ -12,24 +12,13 @@ const WineList = ({ data }) => {
 
   return data.map((o) => (
     <Link
-      className={
-        JSON.stringify(Array.of(o)) ===
-        JSON.stringify(listWineName.filter((wine) => wine === o))
-          ? "card-link disable"
-          : "card-link"
-      }
+      className={listWineName.includes(o) ? "card-link disable" : "card-link"}
       key={o}
-      to={
-        JSON.stringify(Array.of(o)) ===
-        JSON.stringify(listWineName.filter((wine) => wine === o))
-          ? null
-          : `/${o}/visuel`
-      }
+      to={listWineName.includes(o) ? null : `/${o}/visuel`}
     >
       <section className="card">
         <h2 className="card-title">{o}</h2>
-        {JSON.stringify(Array.of(o)) ===
-        JSON.stringify(listWineName.filter((wine) => wine === o)) ? (
+        {listWineName.includes(o) ? (
           <img className="card-img" src={GlassWine} alt="déguster" />
         ) : (
           <img className="card-img" src={Glasses} alt="à déguster" />


### PR DESCRIPTION
    JSON.stringify(listWineName.filter((wine) => wine === o))

On sait que ça ne laissera dans le tableau que le vin `o`. Donc si `o` est dans la liste la comparaison produite revient à :

    "[o]" === "[o]"

Ce qui aurait pu être :

    o === o

Vu que `o` est une string.

Si `o` n'est pas dans la liste, ça donnera :

    "[o]" === "[]"

Ce qui aurait pu être :

    o === undefined|null|n'importe quoi qui ne soit pas o

Au final, ça revient à regarder si `listWineName` contient `o` :

    listWineName.includes(o)

Note : ça marche parce que le tableau contient des strings. Pour des valeurs non primitives, ton approche aurait été la bonne ;)