### PR TITLE
removed score system for like buttons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,14 +15,10 @@ const allLinks = {
   },
   ["gustatif"]: {
     previous: "olfactif",
-    next: "score",
-  },
-  ["score"]: {
-    previous: "gustatif",
     next: "summary",
   },
   ["summary"]: {
-    previous: "score",
+    previous: "gustatif",
   },
 };
 
@@ -47,7 +43,6 @@ function App() {
       flavors: sessionStorage.getItem("flavors"),
       framework: sessionStorage.getItem("framework"),
       aromaticPersistence: sessionStorage.getItem("aromaticPersistence"),
-      score: sessionStorage.getItem("score"),
     });
     setDataWine(dataWine);
   };
@@ -70,18 +65,6 @@ function App() {
     sessionStorage.getItem("framework"),
     sessionStorage.getItem("aromaticPersistence"),
   ].filter((o) => o !== null).length;
-  
-  const dataCheckedScore = [sessionStorage.getItem("score")].filter(
-    (o) => o !== null
-  ).length;
-
-  console.log(
-    "test",
-    dataCheckedVisual,
-    dataCheckedOlfactif,
-    dataCheckedGustatif,
-    dataCheckedScore
-  );
 
   return (
     <>
@@ -113,14 +96,6 @@ function App() {
           {lastUrlSegment === "gustatif" && (
             <Link
               className={dataCheckedGustatif === 3 ? "link" : "app-disable"}
-              to={`/${id}/${links.next}`}
-            >
-              Suivant
-            </Link>
-          )}
-          {lastUrlSegment === "score" && (
-            <Link
-              className={dataCheckedScore === 1 ? "link" : "app-disable"}
               to={`/${id}/${links.next}`}
             >
               Suivant

--- a/src/contexts/WineContext.jsx
+++ b/src/contexts/WineContext.jsx
@@ -93,7 +93,6 @@ export function WineContextProvider({ children }) {
   const [aromaticPersistence, setAromaticPersistence] = useState(
     sessionStorage.getItem("AromaticPersistence")
   );
-  const [score, setScore] = useState(sessionStorage.getItem("score"));
 
   const wineManage = useMemo(() => {
     return {
@@ -123,8 +122,6 @@ export function WineContextProvider({ children }) {
       setFramework,
       aromaticPersistence,
       setAromaticPersistence,
-      score,
-      setScore,
     };
   }, [
     levelWines,
@@ -140,7 +137,6 @@ export function WineContextProvider({ children }) {
     flavors,
     framework,
     aromaticPersistence,
-    score,
   ]);
 
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -14,7 +14,6 @@ import Olfactory from "./pages/Olfactory";
 import Taste from "./pages/Taste";
 import Summary from "./pages/Summary";
 
-import Score from "./pages/Score";
 import Workshop from "./pages/Workshop";
 import Finish from "./pages/Finish";
 
@@ -75,10 +74,6 @@ const router = createBrowserRouter([
       {
         path: "summary",
         element: <Summary />,
-      },
-      {
-        path: "score",
-        element: <Score />,
       },
     ],
   },

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -30,7 +30,6 @@ const Profile = () => {
               <p>Saveurs: {o.flavors ?? ""}</p>
               <p>Structure: {o.framework ?? ""}</p>
               <p>Persistance aromatique: {o.AromaticPersistence ?? ""}</p>
-              <p>score: {o.score ?? ""}</p>
             </div>
           ))}
         </div>

--- a/src/pages/Summary.jsx
+++ b/src/pages/Summary.jsx
@@ -1,12 +1,27 @@
-import { useParams } from "react-router-dom";
+import { useParams, useRevalidator } from "react-router-dom";
 
 const Summary = () => {
   const { id } = useParams();
+  const revalidator = useRevalidator();
+
+  const colorShadeLike =
+    (sessionStorage.getItem(`${id}.colorShadeLike`) ?? "false") !== "false";
 
   return (
     <>
       <h1>Vin choisi: {id} </h1>
-      <p>Couleur et nuance: {sessionStorage.getItem("colorShade")}</p>
+      <p>
+        Couleur et nuance: {sessionStorage.getItem("colorShade")}{" "}
+        <button
+          type="button"
+          onClick={() => {
+            sessionStorage.setItem(`${id}.colorShadeLike`, !colorShadeLike);
+            revalidator.revalidate(); // "recharge" la page
+          }}
+        >
+          {colorShadeLike ? "❤️" : "🖤"}
+        </button>
+      </p>
       <p>Brillance: {sessionStorage.getItem("shine")}</p>
       <p>Intensité de la couleur: {sessionStorage.getItem("colorIntensity")}</p>
       <p>Fluidité des larmes: {sessionStorage.getItem("fluidityOfTears")}</p>
@@ -19,7 +34,6 @@ const Summary = () => {
         Persistance aromatique:
         {sessionStorage.getItem("aromaticPersistence")}
       </p>
-      <p>Score:{sessionStorage.getItem("score")}</p>
     </>
   );
 };


### PR DESCRIPTION
J'ai retiré la page Score du parcours utilisateur (j'ai laissé du ménage à faire :p) et ajouté un premier bouton like. L'implémentation est un peu "quick and dirty", mais ça fonctionne.

Je crois aussi avoir identifié les bizarreries de navigation : tous les vins utilisent les mêmes noms de clé. Par exemple :

    sessionStorage.getItem("colorShade")

Chaque vin gouté devrait avoir son propre `"colorShade"`, et donc une clé unique du genre `"Grenache.colorShade"`. J'ai mis un exemple sur mon bouton like avec le nom du vin récupéré depuis l'url :

    const { id } = useParams();

    sessionStorage.getItem(`${id}.colorShadeLike`)