### PR TITLE
refactored SliderWorkshop to remove useEffect

### DIFF
--- a/src/components/SliderWorkshop.jsx
+++ b/src/components/SliderWorkshop.jsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useWine } from "../contexts/WineContext";
 
 import Slider from "@mui/material/Slider";
 import Stack from "@mui/material/Stack";
+
+const valueStep = 5;
 
 const SliderWorkshop = (props) => {
   const slideWineLevel = [
@@ -68,27 +70,27 @@ const SliderWorkshop = (props) => {
   const [value, setValue] = useState(
     props.maxScore === props.wine.wineName ? 125 : 0
   );
-  const [valueStep, setValueStep] = useState(5);
 
   const handleChange = (e) => {
-    if (value <= 250) {
-      setValue(e.target.value);
-      sessionStorage.setItem(`${e.target.name}`, e.target.value);
-    }
-  };
+    sessionStorage.setItem(`${e.target.name}`, e.target.value); // update storage
 
-  useEffect(() => {
+    // compute total
     const winesLevel = dataWine
       .map((wine) => parseInt(sessionStorage.getItem(wine.wineName)))
       .reduce((acc, current) => current + acc);
 
+    // check total
     if (winesLevel <= 250) {
+      setValue(e.target.value); // update state : this will update slider rendering
+
       setLevelWines(winesLevel);
-      setValueStep(5);
     } else {
-      setValueStep(0);
+      sessionStorage.setItem(`${e.target.name}`, value); // restore previous value in storage
+
+      // state is kept unchanged
+      // slider is rendered with an unchanged value and looks "blocked"
     }
-  }, [value]);
+  };
 
   return (
     <>


### PR DESCRIPTION
Simplification du code :

    const handleChange = (event) => {
       setSomeState(event.target.value);
    };

    useEffect(() => {
      // do something with the state
    }, [someState]);

Peut devenir :

    const handleChange = (event) => {
       setSomeState(event.target.value);

      // do something with event.target.value

      // someState is not updated synchronously
    };

Cela saute un useEffect, un rendu, et enlève du code ;)
